### PR TITLE
Implement user authorization

### DIFF
--- a/api.md
+++ b/api.md
@@ -195,3 +195,42 @@ DELETE /events/{id}
 ```
 Status: 204 NO CONTENT
 ```
+
+## User Registration
+```
+POST /signup
+```
+### Input example
+
+```json
+{
+  "email": "example@example.com",
+  "First Name": "Ashlyn",
+  "Last Name": "Baum",
+  "Password": "******" 
+}
+### Response
+```
+Status: 200 ok
+```
+```json{
+  "id": "507f1f77bcf86cd799439012"
+}
+## User Authentication
+```
+POST /login
+```
+### Input Example
+```json{
+  "email": "example@example.com",
+  "Password": "****"
+}
+### Response
+```
+Status: 200 ok
+```
+```json{
+  "id": "507f1f77bcf86cd799439012"
+}
+```
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "~4.11.2",
     "body-parser": "~1.12.2",
     "mongodb": "^2.0.27",
-    "bcrypt": "^0.8.2"
+    "bcrypt": "^0.8.2",
     "basic-auth": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "body-parser": "~1.12.2",
     "mongodb": "^2.0.27",
     "bcrypt": "^0.8.2"
+    "basic-auth": "^1.0.0"
   },
   "devDependencies": {
     "nodemon": "^1.3.7"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "express": "~4.11.2",
     "body-parser": "~1.12.2",
-    "mongodb": "^2.0.27"
+    "mongodb": "^2.0.27",
+    "bcrypt": "^0.8.2"
   },
   "devDependencies": {
     "nodemon": "^1.3.7"

--- a/server.js
+++ b/server.js
@@ -30,6 +30,11 @@ function formatEvent(event){
 
 var formatUser = formatEvent
 
+function validateEmail(email) {
+    var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+    return re.test(email);
+}
+
 MongoClient.connect(url, function (err, db) {
   if (err) {
     console.log('Unable to connect to the mongoDB server. Error:', err);
@@ -89,14 +94,10 @@ MongoClient.connect(url, function (err, db) {
     // Get the users doc
     var usersCollection = db.collection('users')
 
-    function validateEmail(email) {
-        var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
-        return re.test(email);
-    }
 
     app.post('/signup', function(req, res){
-      var email = validateEmail(req.body.email);
-      if (email == false){
+      var isEmail = validateEmail(req.body.email);
+      if (!isEmail){
         res.status(422).send("Invalid email")
       } else {
         bcrypt.genSalt(10, function(err, salt) {

--- a/server.js
+++ b/server.js
@@ -226,20 +226,24 @@ MongoClient.connect(url, function (err, db) {
     //Basic Auth Login
     app.get('/', function(req, res){
       var basicAuthUser = basicAuth(req);
-      usersCollection.findOne( {email: basicAuthUser.name}, function(err, user){
-        if (!user){
-          res.status(403).end()
-        } else {
-          bcrypt.compare( basicAuthUser.pass , user.encryptedPassword, function(err, isSame) {
-            if (isSame){
-              user = formatUser(user);
-              res.status(200).send({auth_token: user.authToken});
-            } else{
-              res.status(403).end()
-            }
-          });
-        }
-      });
+      if (!basicAuthUser) {
+        return res.status(403).end()
+      } else {
+        usersCollection.findOne( {email: basicAuthUser.name}, function(err, user){
+          if (!user){
+            res.status(403).end()
+          } else {
+            bcrypt.compare( basicAuthUser.pass , user.encryptedPassword, function(err, isSame) {
+              if (isSame){
+                user = formatUser(user);
+                res.status(200).send({auth_token: user.authToken});
+              } else{
+                res.status(403).end()
+              }
+            });
+          }
+        });
+      }
     });
 
   }

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var url = ( process.env.MONGOLAB_URI  || 'mongodb://localhost:27017/yoga' );
 
 var ObjectID = require('mongodb').ObjectID;
 var bcrypt = require('bcrypt');
-
+var basicAuth = require('basic-auth')
 var bodyParser = require('body-parser');
 
 app.use(bodyParser.json());
@@ -193,6 +193,25 @@ MongoClient.connect(url, function (err, db) {
             if (isSame){
               user = formatUser(user);
               res.status(200).send(user.id);
+            } else{
+              res.status(403).end()
+            }
+          });
+        }
+      });
+    });
+
+    //Basic Auth Login
+    app.get('/', function(req, res){
+      var basicAuthUser = basicAuth(req);
+      usersCollection.findOne( {email: basicAuthUser.name}, function(err, user){
+        if (!user){
+          res.status(403).end()
+        } else {
+          bcrypt.compare( basicAuthUser.pass , user.encryptedPassword, function(err, isSame) {
+            if (isSame){
+              user = formatUser(user);
+              res.status(200).send("authentication token is " + user.authToken);
             } else{
               res.status(403).end()
             }

--- a/server.js
+++ b/server.js
@@ -94,10 +94,7 @@ MongoClient.connect(url, function (err, db) {
       eventsCollection.find({}).toArray(function(err, events) {
 
         // modify events to make rename each "_id" to "id"
-        
         events = events.map(formatEvent)
-
-        console.log('error', err)
         res.send(err || events);
       });
     });

--- a/server.js
+++ b/server.js
@@ -54,7 +54,13 @@ MongoClient.connect(url, function (err, db) {
 
     // authorization middleware
     var auth = function(req, res, next) {
-      var authToken = req.get("X-Auth-Token")
+      req = req.req || req;
+      var authToken = req.headers.authorization;
+      if (!auth) return;
+      var parts = authToken.split(' ');
+      if ('token' != parts[0].toLowerCase()) return;
+      if (!parts[1]) return;
+      authToken = parts[1];
       usersCollection.findOne( { authToken: authToken }, function(err, user){
         if(user) {
           req.user = user;
@@ -211,7 +217,7 @@ MongoClient.connect(url, function (err, db) {
           bcrypt.compare( basicAuthUser.pass , user.encryptedPassword, function(err, isSame) {
             if (isSame){
               user = formatUser(user);
-              res.status(200).send("authentication token is " + user.authToken);
+              res.status(200).send({auth_token: user.authToken});
             } else{
               res.status(403).end()
             }

--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ var createEvent = function(attr){
 };
 
 
-function validateEmail(email) {
+var validateEmail = function validateEmail(email) {
     var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
     return re.test(email);
 }
@@ -142,7 +142,7 @@ MongoClient.connect(url, function (err, db) {
         return rand() + rand() + rand() + rand(); // to make string 32 characters
     };
 
-    function isTokenInDB(token, cb) {
+    var isTokenInDB = function isTokenInDB(token, cb) {
       usersCollection.findOne( {authToken: token}, function(err, user) {
         cb(null, user && true)
       });

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ app.use(bodyParser.json());
 
 // upgrade to https
 var requireHTTPS= function(req, res, next){
-  if (!req.secure) {
+  if (req.get('X-Forwarded-Proto') === "http") {
     // for api use only
     return res.status(426).end();
     // for redirection

--- a/server.js
+++ b/server.js
@@ -12,7 +12,26 @@ var bodyParser = require('body-parser');
 
 app.use(bodyParser.json());
 
-// *** Utilities *** 
+// upgrade to https
+var requireHTTPS= function(req, res, next){
+  if (!req.secure) {
+    // for api use only
+    return res.status(426).end();
+    // for redirection
+    // return res.redirect('https://' + req.headers.host + req.url);
+  }
+  next();
+};
+
+// only active on heroku
+/*
+ app.get('env') will check the environment variable NODE_ENV
+ if not defined: it will automatically be define as development
+ NODE_ENV = "production" is set as an environment variable in Heroku
+*/
+if (app.get('env') === "production") app.use(requireHTTPS);
+
+// *** Utilities ***
 var clone = function(obj) {
   return JSON.parse(JSON.stringify(obj));
 }

--- a/server.js
+++ b/server.js
@@ -249,4 +249,7 @@ MongoClient.connect(url, function (err, db) {
   }
 });
 
-var server = app.listen(process.env.PORT || 3000);
+var port = process.env.PORT || 3000;
+var server = app.listen(port, function() {
+  console.log('server listening on '+ port);
+});

--- a/server.js
+++ b/server.js
@@ -140,11 +140,8 @@ MongoClient.connect(url, function (err, db) {
       isTokenInDB(token, function(err, result) {
         if (result) {
           return genUniqueToken(cb);
-          console.log("token is token" + token)
-        } 
-        else{
+        } else{
           return cb(null, token);
-          console.log("is token" + token)
         }
       });
     };
@@ -164,7 +161,6 @@ MongoClient.connect(url, function (err, db) {
                         res.status(200).send("authToken is " + uniqueToken);
                       });
                     });
-                      // res.status(200).send(formatUser(user).id);
                   } else{
                     res.status(422).send("This user email already exists.")
                   }

--- a/server.js
+++ b/server.js
@@ -55,7 +55,7 @@ MongoClient.connect(url, function (err, db) {
     // authorization middleware
     var auth = function(req, res, next) {
       var authToken = req.get("X-Auth-Token")
-      usersCollection.findOne( {"_id": ObjectID(authToken)}, function(err, user){
+      usersCollection.findOne( { authToken: authToken }, function(err, user){
         if(user) {
           req.user = user;
           next()

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ var formatUser = formatEvent
 
 var createEvent = function(attr){
   return {
-    "title": attr.title,
+    title: attr.title,
     creatorID: null
   }
 };

--- a/server.js
+++ b/server.js
@@ -133,7 +133,20 @@ MongoClient.connect(url, function (err, db) {
 
 
     // Get the users doc
+    // send random auth
+    var rand = function() {
+        return Math.random().toString(16).substr(2); //base 16 for hex and subtract 2 moves the decimal place
+    };
 
+    var genToken = function() {
+        return rand() + rand() + rand() + rand(); // to make string 32 characters
+    };
+
+    function isTokenInDB(token, cb) {
+      usersCollection.findOne( {authToken: token}, function(err, user) {
+        cb(null, user && true)
+      });
+    };
     // check that token does not already exist
     function genUniqueToken(cb) {
       var token = genToken()


### PR DESCRIPTION
# Implementation progress
- [x] Registration - plain text passwords
- [x] Login - `(email, password) => id`
- [x] Encrypt password 
- [x] Authorize users based on `id` - secure resources
- [x] Check email validity
- [x] Authentication based on generated secure tokens
- [x] Basic Access Authentication & `Authorization` header
- [x] HTTPS!
- [x] Race condition on token generation

![XKCD Security](http://imgs.xkcd.com/comics/security.png)
https://xkcd.com/538/
# Definitions

Three importants definitons taken from https://stackoverflow.com/questions/6556522/authentication-versus-authorization
- **Identification** is claiming you are somebody
- **Authentication** is the process of ascertaining that somebody really is who he claims to be.
- **Authorization** refers to rules that determine who is allowed to do what. E.g. Adam may be authorized to create and delete databases, while Usama is only authorised to read.
# Implementation steps
## Registration - plain text passwords

Endpoint that receive `email` and `password` and store them in the database.
## Login - returns id as authentication token

Just a simple endpoint that that returns the `id` of a user **identified** by his `email` and then **authenticated** by his password.

The reason why we return the `id` here is because we are going to assume that the `id` is secret enought that you can authorize someone to create an event or modify an event by just providing his user `id` and the `creatorId` of an event.
## Authorize users based on `id` - secure resources

We are now going to secure our events CRUD. The reading actions ( list events and show an event ) are public but the other are not.
At the moment we using the `id` of the user as his authentication token and pass the token as a `X-Auth-Token` header for authorized requests.

These simple authorizations define how we protect our event resource :
- Any unauthenticated user can read events
- Any authenticated user can create an event
- Update an event requires to be the `creator` of the event
- Delete an event requires to be the `creator` of the event

This implementation can be splited in a few step itself:
- [x] Attach events to users when events are created
- [x] Authenticate users based on his authentication token for each secure endpoint
- [x] Implement authorizations

**Don't forget to hide the `creatorId` of events since it's the secret use to identify and authenticate them !**
## Check email validity

At the moment it's possible with "@WoOoT@" as a valid email address and that's an issue, especialy if we want to confirm email adresses later. The [SMTP server](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) is going to be very angry against us.

I think you already found a regex for this, so just use it and we're going to analyze it together later.
## Authentication based on generated secure tokens

User `id` is not the best way to authenticate a user for a frew reasons. We are going to make userId public, to be able to request things such as `GET /users/{id}` to see a profile and also because it's easy to predict [MongoDB ObjectID](http://docs.mongodb.org/manual/reference/object-id/).

We are going to generate random strings such as `7704853336302830aaa609584bb1fa426a00c6331a47e13851b710b4e18a42f4` to authenticate our users.
Because a computer is **deterministic**, it's impossible to generate randomness with a programm. To generate "random numbers", entropy comes from, temperature captors, electronic signal noise, mouse mouvements, everything that's difficult to predict is part of the equasion...

node.js strandard library comes with a [`crypto`](https://nodejs.org/api/crypto.html) package that have a [`crypto.randomBytes` function](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback).
There is a comment about the fact that the function call might fail. Our strategy is to wait for using [`setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout) and retry generating the random number.
## Basic Access Authentication & `Authorization` header

Using a header named `X-Auth-Token` to sent the token and passing user credentials as a json playload in the `POST /login` was very simple way to transfert those data. Unfortunatly none of those are very standart even if there are 

Like any other header, the `Authorization` one is just a string value sent between the server and the client but there are a few conventions around this header.
The `Authorization` header is part of the [RFC1945](https://tools.ietf.org/html/rfc1945) that define the HTTP/1.0 protocol... [Section 10.2](https://tools.ietf.org/html/rfc1945#section-10.2) and [Section 11(https://tools.ietf.org/html/rfc1945#section-11). You'll find in these two sections everything you need to change the `POST /login` endpoint.
### Basic Scheme

So, instead of sending `email` and `password` through a json playload, we are going to use the [Authorization Basic Scheme](https://tools.ietf.org/html/rfc1945#section-11.1).
The Basic Sheme requires to encode and decode using the [standard base64 encoding](https://en.wikipedia.org/wiki/Base64) you can play with base64 encoding using `openssl` as in the following examples, for node.js you can either use Javascript `btoa` and `atob` functions or use node's [Buffer#toString](https://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end) method.

``` bash
# To encode
$ echo "encode this" | openssl enc -base64
ZW5jb2RlIHRoaXMK

# To decode
$ echo "ZW5jb2RlIHRoaXMK" | openssl enc -d -base64
encode this
```

So at the end, a request like this should return a user authentication token:

```
GET /
Authorization: Basic PDMgQXNobHluCg==
```

_Notice that I expect to `GET /` and not `POST /login`._
### Token Scheme

We are now following a nice convention for our Authentication process but our Authorization token is still sent in the `X-Auth-Token` header of authenticated requests. We can define our own scheme that's not the Basic one for the purpose of sending the authentication token.

Here is the scheme I suggest to use:

```
basic-credentials = "Token" SP token
token             = <user token string>
```
## HTTPS!

Last but not least, I want the server to respond `426 Upgrade Required` for any non HTTPS request. No content, don't do anything, just catch all non HTTPS requests and send a `426` status.

Unfortunatly there is no way to disable the `80` port on heroku...
## Race condition on token generation

When you send multiple http requests to a node.js server, those requests are processes concurently, which mean that requests are processes about at the same time.

``` javascript
var genUniqueToken = function(cb) {
  var token = genToken();
  isTokenInDatabase(function(isPresent) {
    if(isPresent) {
      genUniqueToken(cb);
    } else {
      cb(null, token);
    }
  })
};

genUniqueToken(function(err, token) {
  // t1
  insertInDatabase({token: token}, function(err, result) {
    // t2
  });
});
```

If you have two request executing concurently the previous code with `t1` < `t1'` < `t2` < `t2'` ( `t1` is the time when the code following the comment `t1` is exectuted ) and by an impossible hazard the two request have generated the same token, then you'll have two documents with the same token in your database... because both requests checked the existance of the token before the other inserted the new document.

To ensure that it's not possible to have two document with the same token, you'll have to use a [mongodb index](http://docs.mongodb.org/manual/core/indexes-introduction/).

[`Collection#ensureIndex`](https://mongodb.github.io/node-mongodb-native/markdown-docs/indexes.html#ensure-indexes-with-ensureindex) is what you need to create an index.

In case of index violation, a call to collection.insert will give you back an error...
